### PR TITLE
Question threshold

### DIFF
--- a/wagtail_streamfield_migration_toolkit/autodetect/questioner.py
+++ b/wagtail_streamfield_migration_toolkit/autodetect/questioner.py
@@ -3,14 +3,14 @@ from django.db.migrations.questioner import InteractiveMigrationQuestioner
 
 # TODO determine if we write our own. We won't be using most of the methods in this
 class InteractiveDataMigrationQuestioner(InteractiveMigrationQuestioner):
-    def ask_block_rename(self, old_path, new_path):
+    def ask_if_block_renamed(self, old_path, new_path):
         msg = "Was '{}' renamed to '{}' ? [y/N]"
         return self._boolean_input(msg.format(old_path, new_path))
 
-    def ask_block_remove(self, old_path):
+    def ask_if_block_removed(self, old_path):
         msg = "Was '{}' removed? [y/N]"
         return self._boolean_input(msg.format(old_path))
 
-    def ask_block_not_changed(self, old_path):
-        msg = "Is '{}' the same block as before? [y/N]"
-        return self._boolean_input(msg.format(old_path))
+    def ask_if_block_same(self, old_path, new_path):
+        msg = "Found blocks '{}' and '{}' with minor differences. Is this the same block? [y/N]"
+        return self._boolean_input(msg.format(old_path, new_path))

--- a/wagtail_streamfield_migration_toolkit/autodetect/questioner.py
+++ b/wagtail_streamfield_migration_toolkit/autodetect/questioner.py
@@ -10,3 +10,7 @@ class InteractiveDataMigrationQuestioner(InteractiveMigrationQuestioner):
     def ask_block_remove(self, old_path):
         msg = "Was '{}' removed? [y/N]"
         return self._boolean_input(msg.format(old_path))
+
+    def ask_block_not_changed(self, old_path):
+        msg = "Is '{}' the same block as before? [y/N]"
+        return self._boolean_input(msg.format(old_path))

--- a/wagtail_streamfield_migration_toolkit/autodetect/questioner.py
+++ b/wagtail_streamfield_migration_toolkit/autodetect/questioner.py
@@ -1,7 +1,6 @@
 from django.db.migrations.questioner import InteractiveMigrationQuestioner
 
 
-# TODO determine if we write our own. We won't be using most of the methods in this
 class InteractiveDataMigrationQuestioner(InteractiveMigrationQuestioner):
     def ask_if_block_renamed(self, old_path, new_path):
         msg = "Was '{}' renamed to '{}' ? [y/N]"

--- a/wagtail_streamfield_migration_toolkit/autodetect/streamchangedetector.py
+++ b/wagtail_streamfield_migration_toolkit/autodetect/streamchangedetector.py
@@ -88,7 +88,7 @@ class StreamDefChangeDetector:
 
         # To keep track of the block path. We will need this for creating operations and keeping
         # track
-        path_suffix = "" if parent_path == "" else "."
+        path_separator = "" if parent_path == "" else "."
 
         old_child_names = set(old_child_defs.keys())
         new_child_names = set(new_child_defs.keys())
@@ -96,7 +96,7 @@ class StreamDefChangeDetector:
         new_only_child_names = new_child_names - old_child_names
 
         for old_child_name in old_child_names:
-            old_child_path = parent_path + path_suffix + old_child_name
+            old_child_path = parent_path + path_separator + old_child_name
             old_child_def = old_child_defs[old_child_name]
             is_child_mapped = False
 
@@ -109,7 +109,7 @@ class StreamDefChangeDetector:
             if old_child_name in new_child_names:
                 new_child_name = old_child_name
                 new_child_def = new_child_defs[new_child_name]
-                new_child_path = parent_path + path_suffix + new_child_name
+                new_child_path = parent_path + path_separator + new_child_name
 
                 similarity_score = comparer.compare(
                     old_def=old_child_def,
@@ -128,7 +128,9 @@ class StreamDefChangeDetector:
                     is_child_mapped = True
 
                 elif similarity_score >= VERIFYING_SIMILARITY_THRESHOLD:
-                    if self.questioner.ask_block_not_changed(old_path=old_child_path):
+                    if self.questioner.ask_if_block_same(
+                        old_path=old_child_path, new_path=new_child_path
+                    ):
                         # recursion call
                         self.find_renamed_or_removed_defs(
                             old_child_def,
@@ -141,7 +143,7 @@ class StreamDefChangeDetector:
                 blocks_by_score = []
 
                 for new_only_child_name in new_only_child_names:
-                    new_child_path = parent_path + path_suffix + new_only_child_name
+                    new_child_path = parent_path + path_separator + new_only_child_name
                     new_child_def = new_child_defs[new_only_child_name]
 
                     # compare the blocks and find whether they are similar enough to be mapped
@@ -177,7 +179,7 @@ class StreamDefChangeDetector:
                     ) in blocks_by_score:
 
                         # ask user whether the block was indeed renamed
-                        is_renamed = self.questioner.ask_block_rename(
+                        is_renamed = self.questioner.ask_if_block_renamed(
                             old_path=old_child_path, new_path=new_child_path
                         )
                         if is_renamed:
@@ -200,7 +202,9 @@ class StreamDefChangeDetector:
 
             # if there is no block to map this to, check if it has been removed
             if not is_child_mapped:
-                is_removed = self.questioner.ask_block_remove(old_path=old_child_path)
+                is_removed = self.questioner.ask_if_block_removed(
+                    old_path=old_child_path
+                )
                 if is_removed:
                     self.remove_changes.append((old_child_path, old_block_def))
 

--- a/wagtail_streamfield_migration_toolkit/autodetect/streamchangedetector.py
+++ b/wagtail_streamfield_migration_toolkit/autodetect/streamchangedetector.py
@@ -9,16 +9,15 @@ from ..operations import (
     RemoveStructChildrenOperation,
 )
 
+VERIFYING_SIMILARITY_THRESHOLD = 0.4
+CONFIDENT_SIMILARITY_THRESHOLD = 0.85
+
 
 class StreamDefChangeDetector:
     """Compare the old and new StreamField definitions to detect changes.
 
     For now, this can only detect rename or remove changes.
     """
-
-    VERIFYING_SIMILARITY_THRESHOLD = 0.4
-    # TODO this will probably have to be reduced when the arg/kwarg/child comparison is improved
-    CONFIDENT_SIMILARITY_THRESHOLD = 0.9
 
     def __init__(self, old_streamblock_def, new_streamblock_def):
         self.old_streamblock_def = old_streamblock_def
@@ -118,7 +117,7 @@ class StreamDefChangeDetector:
                     new_def=new_child_def,
                     new_name=new_child_name,
                 )
-                if similarity_score >= self.CONFIDENT_SIMILARITY_THRESHOLD:
+                if similarity_score >= CONFIDENT_SIMILARITY_THRESHOLD:
 
                     # recursion call
                     self.find_renamed_or_removed_defs(
@@ -128,7 +127,7 @@ class StreamDefChangeDetector:
                     )
                     is_child_mapped = True
 
-                elif similarity_score >= self.VERIFYING_SIMILARITY_THRESHOLD:
+                elif similarity_score >= VERIFYING_SIMILARITY_THRESHOLD:
                     if self.questioner.ask_block_not_changed(old_path=old_child_path):
                         # recursion call
                         self.find_renamed_or_removed_defs(
@@ -153,7 +152,7 @@ class StreamDefChangeDetector:
                         new_name=new_only_child_name,
                     )
 
-                    if similarity_score >= self.CONFIDENT_SIMILARITY_THRESHOLD:
+                    if similarity_score >= CONFIDENT_SIMILARITY_THRESHOLD:
                         self.find_renamed_or_removed_defs(
                             old_child_def,
                             new_child_def,
@@ -161,7 +160,7 @@ class StreamDefChangeDetector:
                         )  # recursion call
                         is_child_mapped = True
                         break
-                    elif similarity_score >= self.VERIFYING_SIMILARITY_THRESHOLD:
+                    elif similarity_score >= VERIFYING_SIMILARITY_THRESHOLD:
                         blocks_by_score.append(
                             (similarity_score, new_only_child_name, new_child_path)
                         )

--- a/wagtail_streamfield_migration_toolkit/autodetect/streamchangedetector.py
+++ b/wagtail_streamfield_migration_toolkit/autodetect/streamchangedetector.py
@@ -19,11 +19,11 @@ class StreamDefChangeDetector:
     For now, this can only detect rename or remove changes.
     """
 
-    def __init__(self, old_streamblock_def, new_streamblock_def):
+    def __init__(self, old_streamblock_def, new_streamblock_def, questioner=InteractiveDataMigrationQuestioner()):
         self.old_streamblock_def = old_streamblock_def
         self.new_streamblock_def = new_streamblock_def
 
-        self.questioner = InteractiveDataMigrationQuestioner()
+        self.questioner = questioner
 
         # to keep track of mappings for which we need to make an operation
         self.rename_changes = []

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_block_def_compare.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_block_def_compare.py
@@ -82,7 +82,7 @@ class BlockComparerTestCase(TestCase):
         old_name: str,
         new_def: Block,
         new_name: str,
-        predicate: Callable,
+        predicate: Callable[[float], bool],
     ):
         # predicate would be one of the functions `is_similar`, `is_unsure`, `is_dissimilar`
         comparison_score = comparer.compare(

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_block_def_compare.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_block_def_compare.py
@@ -1,5 +1,7 @@
+from typing import Callable
 from django.test import TestCase
 from wagtail.blocks import (
+    Block,
     CharBlock,
     IntegerBlock,
     DateBlock,
@@ -11,19 +13,31 @@ from wagtail.blocks import (
 )
 
 from wagtail_streamfield_migration_toolkit.autodetect.comparers import (
+    BaseBlockDefComparer,
     StreamBlockDefComparer,
     StructBlockDefComparer,
 )
+from wagtail_streamfield_migration_toolkit.autodetect.streamchangedetector import (
+    VERIFYING_SIMILARITY_THRESHOLD,
+    CONFIDENT_SIMILARITY_THRESHOLD,
+)
 
 
-class ThreeFieldStruct(StructBlock):
+class TwoFieldStruct(StructBlock):
     char_block = CharBlock(max_length=255)
     int_block = IntegerBlock()
+
+
+class ThreeFieldStruct(TwoFieldStruct):
     date_block = DateBlock()
 
 
 class FourFieldStruct(ThreeFieldStruct):
     list_char_block = ListBlock(CharBlock())
+
+
+class FiveFieldStruct(FourFieldStruct):
+    word_block = CharBlock(max_length=125)
 
 
 class DiffThreeFieldStruct(StructBlock):
@@ -34,119 +48,191 @@ class DiffThreeFieldStruct(StructBlock):
 
 class NestedStruct1(StructBlock):
     char_block = CharBlock()
-    struct_4f = FourFieldStruct()
-    struct_3f = ThreeFieldStruct()
+    nested_struct_one = FourFieldStruct()
+    nested_struct_two = ThreeFieldStruct()
 
 
 class NestedStruct2(StructBlock):
     char_block = CharBlock()
-    struct_new3f = ThreeFieldStruct()
-    struct_3f = ThreeFieldStruct()
-
-
-class NestedStruct3(StructBlock):
-    char_block = CharBlock()
-    struct_4f = FourFieldStruct()
-    struct_diff = DiffThreeFieldStruct()
+    nested_struct_one = ThreeFieldStruct()
+    nested_struct_two = ThreeFieldStruct()
 
 
 class BlockComparerTestCase(TestCase):
+    # TODO predicates
+    @staticmethod
+    def is_similar(score):
+        return score > CONFIDENT_SIMILARITY_THRESHOLD
+
+    @staticmethod
+    def is_unsure(score):
+        return (
+            score < CONFIDENT_SIMILARITY_THRESHOLD
+            and score > VERIFYING_SIMILARITY_THRESHOLD
+        )
+
+    @staticmethod
+    def is_dissimilar(score):
+        return score < VERIFYING_SIMILARITY_THRESHOLD
+
     def assertBlockComparisonScore(
-        self, comparer, old_def, old_name, new_def, new_name, expected_score
+        self,
+        comparer: BaseBlockDefComparer,
+        old_def: Block,
+        old_name: str,
+        new_def: Block,
+        new_name: str,
+        predicate: Callable,
     ):
-        # TODO check if we should also add an assertion when similarity thresholds are added
+        # predicate would be one of the functions `is_similar`, `is_unsure`, `is_dissimilar`
         comparison_score = comparer.compare(
             old_def=old_def, old_name=old_name, new_def=new_def, new_name=new_name
         )
-        self.assertAlmostEqual(comparison_score, expected_score, delta=0.01)
+        self.assertTrue(predicate(comparison_score))
 
 
 class TestStructBlocks(BlockComparerTestCase):
-    # NOTE These will need to change if we change the logic for comparison
+    def test_same_block(self):
+        # comparing the same blocks should obviously give a score of 1; we would be pretty confident
+        # that they are the same block.
+        self.assertBlockComparisonScore(
+            comparer=StructBlockDefComparer,
+            old_def=FourFieldStruct(),
+            old_name="foo",
+            new_def=FourFieldStruct(),
+            new_name="foo",
+            predicate=self.is_similar,
+        )
 
     def test_diff_names(self):
+        # If names are different we should not be sure if it is the same block
+        # (We have actually used the same block here)
         self.assertBlockComparisonScore(
             comparer=StructBlockDefComparer,
             old_def=FourFieldStruct(),
             old_name="foo",
             new_def=FourFieldStruct(),
             new_name="fee",
-            expected_score=0.524,
+            predicate=self.is_unsure,
         )
 
     def test_removed_children(self):
-        # removed child
+        # When looking at removed children, if there are only one or two children, there is a
+        # significant chance that the two blocks are different.
+        # (We have actually used the same block here)
         self.assertBlockComparisonScore(
             comparer=StructBlockDefComparer,
-            old_def=FourFieldStruct(),
+            old_def=ThreeFieldStruct(),
             old_name="foo",
-            new_def=ThreeFieldStruct(),
+            new_def=TwoFieldStruct(),
             new_name="foo",
-            expected_score=0.881,
+            predicate=self.is_unsure,
+        )
+
+        # When looking at removed children, if there are many children and only one is removed,
+        # we can be fairly confident that the blocks are the same.
+        # (We have actually used the same block here)
+        self.assertBlockComparisonScore(
+            comparer=StructBlockDefComparer,
+            old_def=FiveFieldStruct(),
+            old_name="foo",
+            new_def=FourFieldStruct(),
+            new_name="foo",
+            predicate=self.is_similar,
+        )
+
+        # NOTE that there are probably situations between these that could go either way
+
+        # NOTE that even if the children are very different, (eg: several children are removed),
+        # as long as the blocks have the same name, we cannot be that the blocks are indeed
+        # different.
+        self.assertBlockComparisonScore(
+            comparer=StructBlockDefComparer,
+            old_def=FiveFieldStruct(),
+            old_name="foo",
+            new_def=TwoFieldStruct(),
+            new_name="foo",
+            predicate=self.is_unsure,
         )
 
     def test_added_children(self):
-        # added child, this would return a score of 1 currently. NOTE change if logic changes to
-        # consider additions for children too
+        # added child, this would return a score of 1 currently. NOTE that this will change when
+        # the logic changes to consider additions for children too
         self.assertBlockComparisonScore(
             comparer=StructBlockDefComparer,
             old_def=ThreeFieldStruct(),
             old_name="foo",
             new_def=FourFieldStruct(),
             new_name="foo",
-            expected_score=1,
+            predicate=self.is_similar,
         )
 
     def test_same_name_diff_children(self):
-        # same name, different children
+        # same name, different children. As long as the same name is there, we can't be sure that it
+        # is not the same block.
+        # (We have actually used different blocks here)
         self.assertBlockComparisonScore(
             comparer=StructBlockDefComparer,
             old_def=ThreeFieldStruct(),
             old_name="foo",
             new_def=DiffThreeFieldStruct(),
             new_name="foo",
-            expected_score=0.524,
+            predicate=self.is_unsure,
         )
 
     def test_nested_child_comparison(self):
+        # A small difference in nested children shouldn't require verifying whether the block is the
+        # same.
         self.assertBlockComparisonScore(
             comparer=StructBlockDefComparer,
             old_def=NestedStruct1(),
             old_name="foo",
             new_def=NestedStruct2(),
             new_name="foo",
-            expected_score=0.841,
+            predicate=self.is_similar,
         )
 
     def test_removed_kwargs(self):
+        # For struct blocks with the same names and same children, we can be fairly certain that
+        # they are the same block regardless of changes to kwargs. (This isn't necessarily the case
+        # for non structural blocks)
         self.assertBlockComparisonScore(
             comparer=StructBlockDefComparer,
             old_def=FourFieldStruct(label="FOO", icon="cup"),
             old_name="foo",
             new_def=FourFieldStruct(),
             new_name="foo",
-            expected_score=0.952,
+            predicate=self.is_similar,
         )
 
     def test_diff_name_diff_children(self):
+        # These are clearly different blocks. Even if a user renames a block and then changes
+        # children, that is not something we want to recognize in the autodetector.
         self.assertBlockComparisonScore(
             comparer=StructBlockDefComparer,
             old_def=ThreeFieldStruct(),
             old_name="foo",
             new_def=DiffThreeFieldStruct(),
             new_name="fee",
-            expected_score=0.048,
+            predicate=self.is_dissimilar,
         )
 
 
-class ThreeFieldStream(StreamBlock):
+class TwoFieldStream(StreamBlock):
     char_block = CharBlock()
     int_block = IntegerBlock()
+
+
+class ThreeFieldStream(TwoFieldStream):
     date_block = DateBlock()
 
 
 class FourFieldStream(ThreeFieldStream):
     list_char_block = ListBlock(CharBlock())
+
+
+class FiveFieldStream(FourFieldStream):
+    word_block = CharBlock(max_length=125)
 
 
 class DiffThreeFieldStream(StreamBlock):
@@ -156,48 +242,78 @@ class DiffThreeFieldStream(StreamBlock):
 
 
 class TestStreamBlocks(BlockComparerTestCase):
-    # NOTE These will need to change if we change the logic for comparison
-
-    def test_removed_children(self):
+    def test_same_block(self):
+        # comparing the same blocks should obviously give a score of 1; we would be pretty confident
+        # that they are the same block
         self.assertBlockComparisonScore(
             comparer=StreamBlockDefComparer,
             old_def=FourFieldStream(),
             old_name="foo",
-            new_def=ThreeFieldStream(),
+            new_def=FourFieldStream(),
             new_name="foo",
-            expected_score=0.881,
+            predicate=self.is_similar,
         )
 
+    def test_removed_children(self):
+        # When looking at removed children, if there are only one or two children, there is a
+        # significant chance that the two blocks are different.
+        # (We have actually used the same block here)
+        self.assertBlockComparisonScore(
+            comparer=StreamBlockDefComparer,
+            old_def=ThreeFieldStream(),
+            old_name="foo",
+            new_def=TwoFieldStream(),
+            new_name="foo",
+            predicate=self.is_unsure,
+        )
+
+        # When looking at removed children, if there are many children and only one is removed,
+        # we can be fairly confident that the blocks are the same.
+        # (We have actually used the same block here)
+        self.assertBlockComparisonScore(
+            comparer=StreamBlockDefComparer,
+            old_def=FiveFieldStream(),
+            old_name="foo",
+            new_def=FourFieldStream(),
+            new_name="foo",
+            predicate=self.is_similar,
+        )
+
+        # NOTE that there are probably situations between these that could go either way
+
     def test_added_children(self):
-        # added child, this would return a score of 1 currently. NOTE change if logic changes to
-        # consider additions for children too
+        # added child, this would return a score of 1 currently. NOTE that this will change when
+        # the logic changes to consider additions for children too
         self.assertBlockComparisonScore(
             comparer=StreamBlockDefComparer,
             old_def=ThreeFieldStream(),
             old_name="foo",
             new_def=FourFieldStream(),
             new_name="foo",
-            expected_score=1,
+            predicate=self.is_similar,
         )
 
     def test_same_name_diff_children(self):
-        # same name, different children
+        # same name, different children. As long as the same name is there, we can't be sure that it
+        # is not the same block.
+        # (We have actually used different blocks here)
         self.assertBlockComparisonScore(
             comparer=StreamBlockDefComparer,
             old_def=ThreeFieldStream(),
             old_name="foo",
             new_def=DiffThreeFieldStream(),
             new_name="foo",
-            expected_score=0.524,
+            predicate=self.is_unsure,
         )
 
     def test_diff_name_diff_children(self):
-        # diff name, different children
+        # These are clearly different blocks. Even if a user renames a block and then changes
+        # children, that is not something we want to recognize in the autodetector.
         self.assertBlockComparisonScore(
             comparer=StreamBlockDefComparer,
             old_def=ThreeFieldStream(),
             old_name="foo",
             new_def=DiffThreeFieldStream(),
             new_name="fee",
-            expected_score=0.048,
+            predicate=self.is_dissimilar,
         )

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_streamchangedetector.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_streamchangedetector.py
@@ -117,10 +117,14 @@ class StreamChangeDetectorTests(TestCase):
             self.assertRenameOperationEqual(expected_operation, operation)
 
     @mock.patch(
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_not_changed",
+        return_value=True,
+    )
+    @mock.patch(
         "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_remove",
         return_value=True,
     )
-    def test_nested_struct_child_removed(self, mock_class):
+    def test_nested_struct_child_removed(self, mock_class1, mock_class2):
         comparer = StreamDefChangeDetector(
             NestedStreamBlock(), NestedStreamWithRemovedStructChild()
         )
@@ -142,10 +146,14 @@ class StreamChangeDetectorTests(TestCase):
             self.assertRemoveOperationEqual(expected_operation, operation)
 
     @mock.patch(
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_not_changed",
+        return_value=True,
+    )
+    @mock.patch(
         "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_rename",
         return_value=True,
     )
-    def test_nested_struct_child_renamed(self, mock_class):
+    def test_nested_struct_child_renamed(self, mock_class1, mock_class2):
         comparer = StreamDefChangeDetector(
             NestedStreamBlock(), NestedStreamWithRenamedStructChild()
         )

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_streamchangedetector.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_streamchangedetector.py
@@ -70,7 +70,7 @@ class StreamChangeDetectorTests(TestCase):
         self.assertEqual(len(comparer.merged_operations_and_block_paths), 0)
 
     @mock.patch(
-        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_remove",
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_if_block_removed",
         return_value=True,
     )
     def test_stream_child_removed(self, mock_class):
@@ -95,7 +95,7 @@ class StreamChangeDetectorTests(TestCase):
             self.assertRemoveOperationEqual(expected_operation, operation)
 
     @mock.patch(
-        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_rename",
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_if_block_renamed",
         return_value=True,
     )
     def test_stream_child_renamed(self, mock_class):
@@ -120,11 +120,11 @@ class StreamChangeDetectorTests(TestCase):
             self.assertRenameOperationEqual(expected_operation, operation)
 
     @mock.patch(
-        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_not_changed",
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_if_block_same",
         return_value=True,
     )
     @mock.patch(
-        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_remove",
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_if_block_removed",
         return_value=True,
     )
     def test_nested_struct_child_removed(self, mock_class1, mock_class2):
@@ -149,11 +149,11 @@ class StreamChangeDetectorTests(TestCase):
             self.assertRemoveOperationEqual(expected_operation, operation)
 
     @mock.patch(
-        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_not_changed",
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_if_block_same",
         return_value=True,
     )
     @mock.patch(
-        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_rename",
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_if_block_renamed",
         return_value=True,
     )
     def test_nested_struct_child_renamed(self, mock_class1, mock_class2):
@@ -178,15 +178,15 @@ class StreamChangeDetectorTests(TestCase):
             self.assertRenameOperationEqual(expected_operation, operation)
 
     @mock.patch(
-        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_not_changed",
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_if_block_same",
         return_value=False,
     )
     @mock.patch(
-        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_rename",
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_if_block_renamed",
         return_value=True,
     )
     @mock.patch(
-        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_remove",
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_if_block_removed",
         return_value=False,
     )
     def test_nested_struct_child_renamed_incorrect_input(

--- a/wagtail_streamfield_migration_toolkit/test/tests/test_streamchangedetector.py
+++ b/wagtail_streamfield_migration_toolkit/test/tests/test_streamchangedetector.py
@@ -42,6 +42,9 @@ class NestedStreamWithRenamedStructChild(NestedStreamBlock):
     struct1 = SimpleStructWithRenamedChild()
 
 
+# TODO do we use the same blocks here?
+
+
 class StreamChangeDetectorTests(TestCase):
     def assertRemoveOperationEqual(self, operation1, operation2):
         self.assertEqual(
@@ -173,3 +176,27 @@ class StreamChangeDetectorTests(TestCase):
         ):
             self.assertEqual(expected_block_path, block_path)
             self.assertRenameOperationEqual(expected_operation, operation)
+
+    @mock.patch(
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_not_changed",
+        return_value=False,
+    )
+    @mock.patch(
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_rename",
+        return_value=True,
+    )
+    @mock.patch(
+        "wagtail_streamfield_migration_toolkit.autodetect.questioner.InteractiveDataMigrationQuestioner.ask_block_remove",
+        return_value=False,
+    )
+    def test_nested_struct_child_renamed_incorrect_input(
+        self, mock_class1, mock_class2, mock_class3
+    ):
+        # Make sure the patched functions are actually called in the previous test, and handled
+        # properly
+        comparer = StreamDefChangeDetector(
+            NestedStreamBlock(), NestedStreamWithRenamedStructChild()
+        )
+        comparer.create_data_migration_operations()
+
+        self.assertEqual(0, len(comparer.merged_operations_and_block_paths))


### PR DESCRIPTION
Changed the existing similarity threshold in the autodetector into 2 thresholds, 

- One for when it is very confident that two blocks are the same and doesn't need verification from the user
- One for when it finds 2 blocks to be somewhat similar, but needs to ask the user whether they are the same block